### PR TITLE
changed AES encryption to use the secure PRNG

### DIFF
--- a/GBClient/GBClientAESEncryption/GBClientAESEncryption.go
+++ b/GBClient/GBClientAESEncryption/GBClientAESEncryption.go
@@ -3,6 +3,7 @@ package GBClientAESEncryption
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,15 +16,10 @@ var (
 )
 
 func GenerateRandomByteSlice(size int) (b []byte, err error) {
-	// Courtesy of Kyle Isom, @gokyle
-	devrand, err := os.Open("/dev/random")
-	if err != nil {
-		return
-	}
-	defer devrand.Close()
-
+	// Modified to use the system's strong PRNG (rather than /dev/random)
 	b = make([]byte, size)
-	n, err := devrand.Read(b)
+
+	n, err := rand.Read(b)
 	if err != nil {
 		return
 	} else if size != n {


### PR DESCRIPTION
I just noticed while browsing your code that your AES encryption module uses the insecure `/dev/random` RNG. This is good for statistical purposes, but not so much for security on most OSes. The new one I submitted uses Go's layer on top of the cryptographically secure RNG (`/dev/urandom` on Unix, `CryptGenRandom` API on Windows). 
